### PR TITLE
Fix: handle contexts with unlimited quota

### DIFF
--- a/listcontext.py
+++ b/listcontext.py
@@ -68,7 +68,7 @@ def main():
                 'Name', 'Quota'))
             for context in contexts:
                 print("{:<60} {:<10}".format(context["name"], str(context["usedQuota"]) + "/" + str(
-                    context["maxQuota"])))
+                    context.get("maxQuota", "unlimited"))))
                 if not args.long:
                     continue
                 if context.get("theme") is not None:


### PR DESCRIPTION
This fix handles cases with unlimited quota, `context` contains no value for `maxQuota`.